### PR TITLE
Corrected process() argument syntax to dispel PHP warning

### DIFF
--- a/core/components/mapstv/elements/tv/input/mapstv.class.php
+++ b/core/components/mapstv/elements/tv/input/mapstv.class.php
@@ -34,7 +34,7 @@ class MapsTvInputRender extends modTemplateVarInputRender
         return $corePath.'elements/tv/tpl/mapstv.input.tpl';
     }
 
-    public function process($value, $params = array())
+    public function process($value, array $params = array())
     {
         $corePath = $this->modx->getOption('mapstv.core_path', null, $this->modx->getOption('core_path').'components/mapstv/');
         $assetsUrl = $this->modx->getOption('mapstv.assets_url', null, $this->modx->getOption('assets_url').'components/mapstv/');


### PR DESCRIPTION
Editing the TV on a resource generates a PHP warning like:

> Declaration of MapsTvInputRender::process(,  = Array) should be compatible with modTemplateVarRender::process(, array  = Array)

A simple addition of array to the second argument:

``` public function process($value, $params = array())```

to 
``` public function process($value, array $params = array())```

Fixes #23 

