### PR TITLE
bugfix mapsTv doesnt load on MIGX CMP

### DIFF
--- a/_build/config.json
+++ b/_build/config.json
@@ -18,7 +18,8 @@
                 "file": "mapstv.plugin.php",
                 "events": [
                     "OnTVInputRenderList",
-                    "OnDocFormRender"
+                    "OnDocFormRender",
+                    "OnManagerPageBeforeRender"
                 ]
             }]
         },

--- a/assets/components/mapstv/js/mgr/mapstv.js
+++ b/assets/components/mapstv/js/mgr/mapstv.js
@@ -224,6 +224,8 @@ mapsTv.panel = function(config) {
                     }
                 }
                 ,afterrender: function(){
+                    // return if no resource, maybe cmp
+                    if (!Ext.getCmp("modx-resource-tabs")) return;
                     // Listen to the tabchange on the modx-resource-tabs section
                     // When TV tab is selected, recalculate and set the width of the gmappanel
                     Ext.onReady(function() {

--- a/core/components/mapstv/elements/plugins/mapstv.plugin.php
+++ b/core/components/mapstv/elements/plugins/mapstv.plugin.php
@@ -27,6 +27,7 @@
  */
 $corePath = $modx->getOption('mapstv.core_path', null, $modx->getOption('core_path').'components/mapstv/');
 $assetsUrl = $modx->getOption('mapstv.assets_url', null, $modx->getOption('assets_url').'components/mapstv/');
+$gmapSource = "//maps.google.com/maps/api/js?key=".$modx->getOption("mapstv.api_key", null, null, true);
 
 $modx->lexicon->load('mapstv:default');
 
@@ -39,12 +40,17 @@ switch ($modx->event->name) {
         break;
     
     case 'OnDocFormRender':
-        // Add the Google Maps api to the resource form
-        $source = '//maps.google.com/maps/api/js';
-        if ($modx->getOption('mapstv.api_key', null, null, true)) {
-            $source .= '?key='.$modx->getOption('mapstv.api_key', null, null, true);
-        }
-        $modx->regClientStartupScript($source);
+        // Add the Google Maps api
+        $modx->regClientStartupScript($gmapSource);
         break;
-        
+
+    case "OnManagerPageBeforeRender":
+    	// Add lexicon
+        $modx->controller->addLexiconTopic("mapstv:default");
+        // Register x-type
+        $modx->controller->addJavascript($assetsUrl . "js/mgr/mapstv.js");
+        $modx->controller->addJavascript($assetsUrl . "js/lib/Ext.ux.GMapPanel3.js");
+        // Add the Google Maps api
+        $modx->controller->addJavascript($gmapSource);
+        break;        
 }


### PR DESCRIPTION
When using mapsTv as an Input TV inside MIGX CMP the TV doesnt get displayed. This PR hopefully solved the problem and display mapsTv correct when using on a MIGX CMP.

The PR https://github.com/Sterc/mapsTv/pull/22 only works when using MIGX on Resources but not on MIGX CMP.